### PR TITLE
Feature/fix cls issues

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -42,7 +42,6 @@ import configureStore, { history } from 'utils/configureStore';
 
 // Components
 import NavigationBar from 'components/partials/NavigationBar';
-import Footer from 'components/partials/Footer';
 
 // Assets
 import openGraphImage from 'assets/images/DehliMusikk-OpenGraph.jpg';
@@ -70,6 +69,7 @@ const Products = prerenderedLoadable(() => import("./components/routes/Products"
 const Equipment = prerenderedLoadable(() => import("./components/routes/Equipment"));
 const Faq = prerenderedLoadable(() => import("./components/routes/Faq"));
 const NotFound = prerenderedLoadable(() => import("./components/routes/NotFound"));
+const Footer = prerenderedLoadable(() => import("./components/partials/Footer"));
 
 library.add(
   faBullhorn,
@@ -132,7 +132,7 @@ const App = () => {
         </Helmet>
         <NavigationBar />
         <div className={style.container}>
-          <main>
+          <main style={{minHeight: "100vh"}}>
             <Routes>
               <Route path="*" key={"/404.html"} element={<NotFound />} />
               <Route path="/404" key={"/404.html"} element={<NotFound />} />

--- a/src/components/routes/Home.js
+++ b/src/components/routes/Home.js
@@ -146,7 +146,7 @@ const Home = () => {
                         <meta property="twitter:title" content="Dehli Musikk" />
                         <meta property="twitter:description" content={metaDescription} />
                     </Helmet>
-                    <div className={style.header}>
+                    <div className={style.header} style={{ minHeight: "135px" }}>
                         {renderHeaderImage()}
                         <div className={style.overlay}>
                             <span className={style.logo}>
@@ -155,14 +155,14 @@ const Home = () => {
                         </div>
                     </div>
 
-                    <div className={style.contentSection}>
+                    <div className={style.contentSection} style={{ minHeight: "468px" }}>
                         <header>
                             <h1>Dehli Musikk</h1>
                         </header>
                         <IntroContent />
                     </div>
 
-                    <div className={style.mutedSection}>
+                    <div className={style.mutedSection} style={{ minHeight: "650px" }}>
                         <Container>
                             <h2 className={style.sectionHeader}>
                                 {selectedLanguageKey === "en" ? "Latest updates" : "Siste oppdateringer"}
@@ -182,7 +182,7 @@ const Home = () => {
                         </Container>
                     </div>
 
-                    <div>
+                    <div style={{ minHeight: "650px" }}>
                         <Container>
                             <h2 className={style.sectionHeader}>
                                 {selectedLanguageKey === "en" ? "Latest releases" : "Siste utgivelser"}
@@ -202,7 +202,7 @@ const Home = () => {
                         </Container>
                     </div>
 
-                    <div className={style.mutedSection}>
+                    <div className={style.mutedSection} style={{ minHeight: "650px" }}>
                         <Container>
                             <h2 className={style.sectionHeader}>
                                 {selectedLanguageKey === "en" ? "Latest videos" : "Siste videoer"}
@@ -222,7 +222,7 @@ const Home = () => {
                         </Container>
                     </div>
 
-                    <div>
+                    <div style={{ minHeight: "650px" }}>
                         <Container>
                             <h2 className={style.sectionHeader}>
                                 {selectedLanguageKey === "en" ? "Newest products" : "Nyeste produkter"}
@@ -242,7 +242,7 @@ const Home = () => {
                         </Container>
                     </div>
 
-                    <div className={style.socialMediaSection}>
+                    <div className={style.socialMediaSection} style={{ minHeight: "297px" }}>
                         <div className={style.contentSection}>
                             <h2>
                                 {selectedLanguageKey === "en"

--- a/src/components/template/ExpansionPanel.module.scss
+++ b/src/components/template/ExpansionPanel.module.scss
@@ -61,4 +61,11 @@
 .expansionPanelContent {
   @include transition.transition(max-height 222ms cubic-bezier(0.4, 0, 0.2, 1) 0ms);
   overflow: hidden;
+  &[aria-hidden="true"] {
+    pointer-events: none;
+  }
+
+  &[aria-hidden="false"] {
+    pointer-events: auto;
+  }
 }

--- a/src/components/template/List/ListItem/ListItemThumbnail.js
+++ b/src/components/template/List/ListItem/ListItemThumbnail.js
@@ -5,9 +5,23 @@ import { Link } from 'react-router-dom';
 import style from 'components/template/List/ListItem/ListItemThumbnail.module.scss';
 
 const ListItemThumbnail = ({ fullscreen, compact, link, children }) => {
-
+const getImageSize = () => {
+    const image = children?.props?.children?.find(child => {
+      if (child?.type === 'img' && child?.props?.height && child?.props?.width) {
+        return true;
+      }
+    });
+    if (image) {
+      return {
+        width: image.props.width,
+        height: image.props.height
+      };
+    }
+    return null;
+  }
+const imageSize = getImageSize();
   const childElements = (
-    <figure className={`${style.listItemThumbnail} ${fullscreen ? style.fullscreen : ''} ${compact ? style.compact : ''}`}>
+    <figure className={`${style.listItemThumbnail} ${fullscreen ? style.fullscreen : ''} ${compact ? style.compact : ''}`} style={imageSize ? { aspectRatio: `${imageSize.width} / ${imageSize.height}` } : {}}>
       <picture>{children}</picture>
     </figure>
   );

--- a/src/components/template/List/ListItem/ListItemThumbnail.module.scss
+++ b/src/components/template/List/ListItem/ListItemThumbnail.module.scss
@@ -5,6 +5,8 @@
   width: 55px;
   height: 55px;
   margin: 9px 6px;
+  border-radius: 50%;
+  background-color: #e5e5e5;
 
   & picture {
     display: block;
@@ -26,10 +28,12 @@
       width: 100%;
       height: auto;
       margin: 0;
+      border-radius: 0;
       &:not(.compact) {
         & picture {
           & img {
             width: 100%;
+            color: red;
             height: auto;
             border-radius: 0;
             border: none;


### PR DESCRIPTION
Improves CLS by adjusting expansion panel and image thumbnails.

This pull request addresses Cumulative Layout Shift (CLS) issues by improving the ExpansionPanel component to pre-calculate and set the content height and by calculating and applying aspect ratios to ListItemThumbnail components. The Footer component is also lazy loaded.

### Changes

- **ExpansionPanel.js/module.scss**: Modified the `ExpansionPanel` component to use `useLayoutEffect` to calculate `maxHeight` before paint, preventing layout shifts. Added `aria-hidden` and `inert` attributes to improve accessibility and prevent interaction with collapsed content. Styles adjusted to accommodate `aria-hidden` and `inert` attributes.
- **ListItemThumbnail.js/module.scss**: Implemented aspect ratio calculation for images within the `ListItemThumbnail` component. This ensures that thumbnails maintain their proportions during loading, preventing layout shifts. Added default background color to thumbnail.
- **App.js**: Moved `Footer` component to be loaded as a lazy-loaded component and set `minHeight` to `100vh` for the main element to prevent content from jumping if content is shorter than the screen.
- **Home.js**: Added `minHeight` styles to `div` elements within the `Home` component to prevent layout shift during content loading.

### Impact

- **Behavioral changes**: Expansion panels now expand and collapse more smoothly without causing layout shifts. Image thumbnails maintain their aspect ratios during loading.
- **Performance implications**: Calculating height and aspect ratios up-front may have a minor performance cost, but it significantly improves the user experience by reducing layout shifts. The lazy loading of the `Footer` component should also improve initial load time.
- **Dependencies affected**: None.
