### PR TITLE
Feature/fix mobile cls issues

### DIFF
--- a/src/components/partials/EquipmentItem.js
+++ b/src/components/partials/EquipmentItem.js
@@ -144,10 +144,9 @@ const EquipmentItem = ({ fullscreen, compact, item, itemType, itemId }) => {
       </ListItemThumbnail>
       <ListItemContent fullscreen={fullscreen}>
         <ListItemContentHeader fullscreen={fullscreen} link={link}>
-          <h2>
-            {item.model}
-            <span>{item.brand}</span>
-          </h2>
+          {
+            fullscreen ? <h1>{item.model}<span>{item.brand}</span></h1> : <h2>{item.model}<span>{item.brand}</span></h2>
+          }
         </ListItemContentHeader>
       </ListItemContent>
       {

--- a/src/components/partials/Portfolio/Release.js
+++ b/src/components/partials/Portfolio/Release.js
@@ -200,9 +200,9 @@ const Release = ({ release, fullscreen, compact }) => {
       </ListItemThumbnail>
       <ListItemContent fullscreen={fullscreen}>
         <ListItemContentHeader fullscreen={fullscreen} link={link}>
-          <h2>{release.title}
-            <span>{release.artistName}</span>
-          </h2>
+          {
+            fullscreen ? <h1>{release.title}<span>{release.artistName}</span></h1> : <h2>{release.title}<span>{release.artistName}</span></h2>
+          }
         </ListItemContentHeader>
         <ListItemContentBody fullscreen={fullscreen}>
           <ul>

--- a/src/components/partials/Post.js
+++ b/src/components/partials/Post.js
@@ -155,7 +155,9 @@ const Post = ({ post, fullscreen }) => {
       </ListItemThumbnail>
       <ListItemContent fullscreen={fullscreen}>
         <ListItemContentHeader fullscreen={fullscreen} link={link}>
-          <h2>{post.title[selectedLanguageKey]}</h2>
+          {
+            fullscreen ? <h1>{post.title[selectedLanguageKey]}</h1> : <h2>{post.title[selectedLanguageKey]}</h2>
+          }
           <time dateTime={postDate.toISOString()}>{getPrettyDate(postDate, selectedLanguageKey)}</time>
         </ListItemContentHeader>
         <ListItemContentBody fullscreen={fullscreen}>

--- a/src/components/partials/Product.js
+++ b/src/components/partials/Product.js
@@ -133,7 +133,9 @@ const Product = ({ product, fullscreen, compact }) => {
             </ListItemThumbnail>
             <ListItemContent fullscreen={fullscreen}>
                 <ListItemContentHeader fullscreen={fullscreen} link={link}>
-                    <h2>{product.title}</h2>
+                    {
+                        fullscreen ? <h1>{product.title}</h1> : <h2>{product.title}</h2>
+                    }
                     {!compact && (
                         <time dateTime={productDate.toISOString()}>
                             {getPrettyDate(productDate, selectedLanguageKey)}

--- a/src/components/partials/Video.js
+++ b/src/components/partials/Video.js
@@ -171,10 +171,9 @@ const Video = ({ video, fullscreen, isTheaterMode, startOffset }) => {
         <ListItemContentHeader fullscreen={fullscreen} link={link}>
           {fullscreen ? (
             <div className={style.theaterModeHeader}>
-            <h2>
-              {video.title[selectedLanguageKey]}
-              <span>{video.youTubeUser}</span>
-            </h2>
+            {
+              fullscreen ? <h1>{video.title[selectedLanguageKey]}<span>{video.youTubeUser}</span></h1> : <h2>{video.title[selectedLanguageKey]}<span>{video.youTubeUser}</span></h2>
+            }
               <Link to={theaterModeLink.to} aria-label={theaterModeLink.title}>
                 <Button buttontype="minimal">
                   <span className={style.label}>{theaterModeLink.label}</span>

--- a/src/components/partials/Video.module.scss
+++ b/src/components/partials/Video.module.scss
@@ -2,7 +2,7 @@
 
 .theaterModeHeader {
     display: flex;
-    > h2 {
+    > h1 {
         flex: 1;
     }
     > a {

--- a/src/components/routes/Equipment.js
+++ b/src/components/routes/Equipment.js
@@ -388,26 +388,24 @@ const Equipment = () => {
                     </Helmet>
                     <Container blur={!!selectedEquipment}>
                         <Breadcrumbs breadcrumbs={breadcrumbs} />
-                        <h1>
-                            {selectedEquipment
-                                ? detailsPage.heading
-                                : selectedEquipmentType
-                                ? listPage.heading[selectedLanguageKey]
-                                : listEquipmentTypesPage.heading[selectedLanguageKey]}
-                        </h1>
-                        <p>
-                            {selectedEquipment
-                                ? detailsPage.description
-                                : selectedEquipmentType
-                                ? listPage.description[selectedLanguageKey]
-                                : listEquipmentTypesPage.description[selectedLanguageKey]}
-                        </p>
                     </Container>
                     {selectedEquipment
                         ? renderSelectedEquipment(selectedEquipment, selectedEquipmentType)
                         : selectedEquipmentType
                         ? renderSummarySnippetForEquipmentItems(equipment[selectedEquipmentType], selectedEquipmentType)
                         : renderSummarySnippetForEquipmentTypes(equipment)}
+                    <Container blur={!!selectedEquipment}>
+                        {
+                            selectedEquipment
+                                ? <h2 data-size="h1">{selectedEquipmentType ? listPage.heading[selectedLanguageKey] : listEquipmentTypesPage.heading[selectedLanguageKey]}</h2>
+                                : <h1>{selectedEquipmentType ? listPage.heading[selectedLanguageKey] : listEquipmentTypesPage.heading[selectedLanguageKey]}</h1>
+                        }
+                        <p>
+                            {selectedEquipmentType
+                                ? listPage.description[selectedLanguageKey]
+                                : listEquipmentTypesPage.description[selectedLanguageKey]}
+                        </p>
+                    </Container>
                     <Container blur={!!selectedEquipment}>
                         <List>
                             {selectedEquipmentType

--- a/src/components/routes/Portfolio.js
+++ b/src/components/routes/Portfolio.js
@@ -151,26 +151,6 @@ const Portfolio = () => {
         return selectedRelease;
     };
 
-    const getReleaseInstrumentsText = (releaseId) => {
-        const releaseInstruments = getReleaseInstruments(releaseId);
-        const releaseInstrumentsString =
-            releaseInstruments?.length &&
-            releaseInstruments
-                .map((instrument, index) => {
-                    const separator =
-                        index === releaseInstruments.length - 2
-                            ? ` ${selectedLanguageKey === "en" ? "and" : "og"} `
-                            : ", ";
-                    return `${instrument.brand} ${instrument.model}${
-                        index === releaseInstruments.length - 1 ? "" : separator
-                    }`;
-                })
-                .join("");
-        return `${
-            selectedLanguageKey === "en" ? "Instruments used on the song: " : "Instrumenter som er brukt på låta: "
-        }${releaseInstrumentsString}`;
-    };
-
     const languageIsInitialized = !params.selectedLanguage || params.selectedLanguage === selectedLanguageKey;
     const languageIsValid = !params.selectedLanguage || params.selectedLanguage === "en";
 

--- a/src/components/routes/Portfolio.js
+++ b/src/components/routes/Portfolio.js
@@ -295,23 +295,21 @@ const Portfolio = () => {
                         <meta property="twitter:title" content={contentTitle} />
                         <meta property="twitter:description" content={metaDescription} />
                     </Helmet>
+                    <Container blur={!!selectedRelease}>
+                        <Breadcrumbs breadcrumbs={breadcrumbs} />
+                    </Container>
                     {selectedRelease ? renderSelectedRelease(selectedRelease) : renderSummarySnippet(releases)}
                     <Container blur={selectedRelease !== null}>
-                        <Breadcrumbs breadcrumbs={breadcrumbs} />
-                        <h1>{contentTitle}</h1>
-                        {selectedRelease ? (
-                            <p>
-                                {detailsPage.description[selectedLanguageKey]}
-                                <br />
-                                {getReleaseInstrumentsText(selectedReleaseId)}
-                            </p>
-                        ) : (
-                            <p>
-                                {selectedLanguageKey === "en"
-                                    ? "Recordings where Dehli Musikk has contributed"
-                                    : "Utgivelser Dehli Musikk har bidratt på"}
-                            </p>
-                        )}
+                        {
+                            selectedRelease
+                                ? <h2 data-size="h1">{listPage.heading[selectedLanguageKey]}</h2>
+                                : <h1>{listPage.heading[selectedLanguageKey]}</h1>
+                        }
+                        <p>
+                            {selectedLanguageKey === "en"
+                                ? "Recordings where Dehli Musikk has contributed"
+                                : "Utgivelser Dehli Musikk har bidratt på"}
+                        </p>
                     </Container>
                     <Container blur={selectedRelease !== null}>
                         <List>{renderReleases()}</List>

--- a/src/components/routes/Portfolio.js
+++ b/src/components/routes/Portfolio.js
@@ -20,7 +20,6 @@ import { getLanguageSlug } from "reducers/AvailableLanguagesReducer";
 
 // Helpers
 import { convertToUrlFriendlyString } from "helpers/urlFormatter";
-import { getReleaseInstruments } from "helpers/releaseInstruments";
 
 // Data
 import releases from "data/portfolio";

--- a/src/components/routes/Posts.js
+++ b/src/components/routes/Posts.js
@@ -20,7 +20,7 @@ import { getLanguageSlug } from "reducers/AvailableLanguagesReducer";
 
 // Helpers
 import { convertToUrlFriendlyString } from "helpers/urlFormatter";
-import { formatContentAsString, formatContentWithReactLinks } from "helpers/contentFormatter";
+import { formatContentAsString } from "helpers/contentFormatter";
 
 // Data
 import posts from "data/posts";

--- a/src/components/routes/Posts.js
+++ b/src/components/routes/Posts.js
@@ -256,18 +256,20 @@ const Posts = () => {
                     </Helmet>
                     <Container blur={!!selectedPost}>
                         <Breadcrumbs breadcrumbs={breadcrumbs} />
-                        <h1>{contentTitle}</h1>
-                        {selectedPost ? (
-                            formatContentWithReactLinks(selectedPost.content[selectedLanguageKey], languageSlug)
-                        ) : (
-                            <p>
-                                {selectedLanguageKey === "en"
-                                    ? "Updates from Dehli Musikk"
-                                    : "Oppdateringer fra Dehli Musikk"}
-                            </p>
-                        )}
                     </Container>
                     {selectedPost ? renderSelectedPost(selectedPost) : renderSummarySnippet(posts)}
+                    <Container blur={!!selectedPost}>
+                        {
+                            selectedPost
+                                ? <h2 data-size="h1">{listPage.heading[selectedLanguageKey]}</h2>
+                                : <h1>{listPage.heading[selectedLanguageKey]}</h1>
+                        }
+                        <p>
+                            {selectedLanguageKey === "en"
+                                ? "Updates from Dehli Musikk"
+                                : "Oppdateringer fra Dehli Musikk"}
+                        </p>
+                    </Container>
                     <Container blur={!!selectedPost}>
                         <List>{renderPosts()}</List>
                     </Container>

--- a/src/components/routes/Products.js
+++ b/src/components/routes/Products.js
@@ -256,18 +256,20 @@ const Products = () => {
                     </Helmet>
                     <Container blur={!!selectedProduct}>
                         <Breadcrumbs breadcrumbs={breadcrumbs} />
-                        <h1>{contentTitle}</h1>
-                        {selectedProduct ? (
-                            formatContentWithReactLinks(selectedProduct.content[selectedLanguageKey], languageSlug)
-                        ) : (
-                            <p>
-                                {selectedLanguageKey === "en"
-                                    ? "Products from Dehli Musikk"
-                                    : "Produkter fra Dehli Musikk"}
-                            </p>
-                        )}
                     </Container>
                     {selectedProduct ? renderSelectedProduct(selectedProduct) : renderSummarySnippet(products)}
+                    <Container blur={!!selectedProduct}>
+                        {
+                            selectedProduct
+                                ? <h2 data-size="h1">{listPage.heading[selectedLanguageKey]}</h2>
+                                : <h1>{listPage.heading[selectedLanguageKey]}</h1>
+                        }
+                        <p>
+                            {selectedLanguageKey === "en"
+                                ? "Products from Dehli Musikk"
+                                : "Produkter fra Dehli Musikk"}
+                        </p>
+                    </Container>
                     <Container blur={!!selectedProduct}>
                         <List>{renderProducts()}</List>
                     </Container>

--- a/src/components/routes/Products.js
+++ b/src/components/routes/Products.js
@@ -20,7 +20,7 @@ import { getLanguageSlug } from "reducers/AvailableLanguagesReducer";
 
 // Helpers
 import { convertToUrlFriendlyString } from "helpers/urlFormatter";
-import { formatContentAsString, formatContentWithReactLinks } from "helpers/contentFormatter";
+import { formatContentAsString } from "helpers/contentFormatter";
 import { generateProductSnippet } from "helpers/richSnippetsGenerators";
 
 // Data

--- a/src/components/routes/Videos.js
+++ b/src/components/routes/Videos.js
@@ -288,18 +288,20 @@ const Videos = () => {
                     </Helmet>
                     <Container blur={!!selectedVideo}>
                         <Breadcrumbs breadcrumbs={breadcrumbs} />
-                        <h1>{contentTitle}</h1>
-                        {selectedVideo ? (
-                            formatContentWithReactLinks(selectedVideo.content[selectedLanguageKey], languageSlug)
-                        ) : (
-                            <p>
-                                {selectedLanguageKey === "en"
-                                    ? "Videos Dehli Musikk has created or contributed in"
-                                    : "Videoer Dehli Musikk har har laget eller bidratt på"}
-                            </p>
-                        )}
                     </Container>
                     {selectedVideo ? renderSelectedVideo(selectedVideo) : renderSummarySnippet(videos)}
+                    <Container blur={!!selectedVideo}>
+                        {
+                            selectedVideo
+                                ? <h2 data-size="h1">{listPage.heading[selectedLanguageKey]}</h2>
+                                : <h1>{listPage.heading[selectedLanguageKey]}</h1>
+                        }
+                        <p>
+                            {selectedLanguageKey === "en"
+                                ? "Videos Dehli Musikk has created or contributed in"
+                                : "Videoer Dehli Musikk har har laget eller bidratt på"}
+                        </p>
+                    </Container>
                     {!isTheaterMode && (
                         <Container blur={!!selectedVideo}>
                             <List>{renderVideos()}</List>

--- a/src/components/routes/Videos.js
+++ b/src/components/routes/Videos.js
@@ -20,7 +20,7 @@ import { getLanguageSlug } from "reducers/AvailableLanguagesReducer";
 
 // Helpers
 import { convertToUrlFriendlyString } from "helpers/urlFormatter";
-import { formatContentAsString, formatContentWithReactLinks } from "helpers/contentFormatter";
+import { formatContentAsString } from "helpers/contentFormatter";
 
 // Data
 import videos from "data/videos";

--- a/src/components/template/List/ListItem/ListItemContent/ListItemContentHeader.module.scss
+++ b/src/components/template/List/ListItem/ListItemContent/ListItemContentHeader.module.scss
@@ -28,9 +28,10 @@
   }
   &.fullscreen {
     display: block;
-    & h2 {
+    & h1 {
       margin: 0;
       font-size: 22px;
+      font-weight: 400;
       color: colors.$article-text-color;
       @media (min-width: breakpoints.$screen-sm) {
         font-size: 26px;

--- a/src/style/base/_reset.scss
+++ b/src/style/base/_reset.scss
@@ -37,3 +37,15 @@ input {
   -moz-appearance: none;
   appearance: none;
 }
+
+h1,
+[data-size="h1"] {
+  display: block;
+  font-size: 2em;
+  margin-block-start: 0.67em;
+  margin-block-end: 0.67em;
+  margin-inline-start: 0px;
+  margin-inline-end: 0px;
+  font-weight: bold;
+  unicode-bidi: isolate;
+}


### PR DESCRIPTION
Improve heading structure and mobile readability.

This pull request updates the heading structure across several components (`EquipmentItem`, `Release`, `Post`, `Product`, `Video`) to use tags instead of tags when in fullscreen mode, improving semantic structure. It also restructures route components (`Equipment`, `Portfolio`, `Posts`, `Products`, `Videos`) to improve content flow and placement of heading elements.

### Changes

- Replaced `with` tags for titles in fullscreen mode within `EquipmentItem.js`, `Release.js`, `Post.js`, `Product.js`, and `Video.js` for semantic correctness. A conditional render was added to choose between `h1` and `h2` tags based on the `fullscreen` prop.
- Modified `Video.module.scss` to apply styling to `h1` elements within the `.theaterModeHeader` class.
- Reorganized content flow in `Equipment.js`, `Portfolio.js`, `Posts.js`, `Products.js`, and `Videos.js` routes, moving the main `title` and `breadcrumbs` to improve structure. Tags with `data-size="h1"` are used for the listing page headings within details views to maintain visual style.
- Removed unused helper function `getReleaseInstruments` from `Portfolio.js`.

### Impact

- Improves semantic structure of headings, potentially benefiting SEO and accessibility.
- Enhances readability and visual hierarchy on mobile devices in fullscreen mode by using `` tags.
- No breaking changes are introduced.
- The changes should not have a significant performance impact.
