### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -1,4 +1,6 @@
 name: Build and Deploy
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/benjamindehli/dehli-musikk/security/code-scanning/6](https://github.com/benjamindehli/dehli-musikk/security/code-scanning/6)

In general, the fix is to explicitly add a `permissions` block restricting the `GITHUB_TOKEN` to the minimal scopes required. Since this workflow only needs to read the repository contents (for `actions/checkout`) and does not perform any GitHub write operations, `contents: read` at the workflow or job level is sufficient. This documents the intent and prevents accidental elevation if defaults change.

The single best way here is to add a workflow‑level `permissions` block after the `name:` line in `.github/workflows/buildAndDeploy.yml`. This will apply to both `build` and `deploy` jobs, without changing any existing behavior of the steps. The block should be:

```yaml
permissions:
  contents: read
```

No new imports, methods, or definitions are needed; it’s a pure YAML configuration change inside this workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
